### PR TITLE
Increase font size for visibility for substeps section

### DIFF
--- a/GUI_detect.py
+++ b/GUI_detect.py
@@ -1323,7 +1323,7 @@ class DisplayGUI:
 
     def build_substeps(self, step):
         for i, s in enumerate(step.substeps):
-            temp = tk.Label(self.substep, text=s,justify='left',anchor='w', bg=dark_theme_background)
+            temp = tk.Label(self.substep, text=s,justify='left',anchor='w', bg=dark_theme_background, font=("Arial", 16))
             temp.pack(fill='x')
             self.substep_list.append(temp)
 


### PR DESCRIPTION
# Simple Fontsize change for the substeps so it is more visible.
- Before
![image](https://github.com/Frankushima/pete/assets/97419450/e3120037-a5aa-4f21-b9e7-1af01fa442c3)
- After
- ![image](https://github.com/Frankushima/pete/assets/97419450/fc42e86b-3253-44fe-9574-d2630f9cd20c)

# Note
Currently set to Arial Fontsize=16