### PR TITLE
Simple Fix for Step5 Substep Priority Issue

### DIFF
--- a/GUI_detect.py
+++ b/GUI_detect.py
@@ -771,7 +771,7 @@ def step5_validator():
                 sub_conditions[0] = True
         # ['found hands', 'found crank arm', 'screwing bolt into crank arm', 'screwed bolt into crank arm'']
         # SUB 1 : is there a pedal wrench? (index = 7)
-        if not sub_conditions[1]:
+        if not sub_conditions[1] and sub_conditions[0] == True:
             crank_count, crank_det = logic_tools.find_class(data, 12)
             if crank_count:
                 # procedure[current_step].update_description(u'Found crank arm👍')


### PR DESCRIPTION
One line fix so that for step 5, subcondition 0 will need to be cleared before subcondition 1 can be cleared.
 
Closes #12 
- Before
![image](https://github.com/Frankushima/pete/assets/97419450/b8712cd4-e673-4e99-9b03-94c1df6d0e78)
 
- After
![image](https://github.com/Frankushima/pete/assets/97419450/58ed80c3-0e12-46b2-b590-fdcfffca5eef)

# Notes/ Thoughts
Could potentially switch the order of subcondition 0 and 1 since Crank arm would most likely be detected first before hands are.